### PR TITLE
27 -  allow document viewer to open on pages other than ones in www/.

### DIFF
--- a/src/windows/sitewaertsdocumentviewerProxy_native.js
+++ b/src/windows/sitewaertsdocumentviewerProxy_native.js
@@ -126,7 +126,7 @@ cordova.commandProxy.add("SitewaertsDocumentViewer", {
 
         // current page must be located in www
         // sitewaertsdocumentviewer must be located in www
-        iframe.src = "./sitewaertsdocumentviewer/viewer.html";
+        iframe.src = "/www/sitewaertsdocumentviewer/viewer.html";
 
         iframe.onload = function ()
         {

--- a/src/windows/sitewaertsdocumentviewerProxy_pdfjs.js
+++ b/src/windows/sitewaertsdocumentviewerProxy_pdfjs.js
@@ -76,7 +76,7 @@ cordova.commandProxy.add("SitewaertsDocumentViewer", {
 
         // current page must be located in www
         // pdfjs must be located in www
-        iframe.src = "./pdfjs/web/viewer.html?file="+encodeURIComponent(url);
+        iframe.src = "/www/pdfjs/web/viewer.html?file="+encodeURIComponent(url);
         var body = document.getElementsByTagName("body")[0];
         viewer.appendChild(iframe);
         viewer.appendChild(close);


### PR DESCRIPTION
This hardcodes the location of pdfjs & sitewaertsdocumentviewer/viewer.js to /www/ instead of ./