### PR TITLE
Change from dependency of android-support-v4-jar to framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,7 +38,7 @@
         </config-file>
 
         <!--see http://stackoverflow.com/questions/38200282/android-os-fileuriexposedexception-file-storage-emulated-0-test-txt-exposed-->
-        <dependency id="cordova-plugin-android-support-v4-jar"/>
+        <framework src="com.android.support:support-v4:+" />
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
 


### PR DESCRIPTION
I think this solves https://github.com/sitewaerts/cordova-plugin-document-viewer/issues/70 as it wont duplicate the support jar when requiring the framework.

Tested by removing the official plugin, adding the forked one with the change and building. The ` com.android.dex.DexException: Multiple dex files define Landroid/support/annotation/AnimRes` error did not appear.

I'm unsure what would happen if the user did not have the android support framework installed via the sdk tools.